### PR TITLE
add exporting of images to a single multi-page PDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/*
+dist/*
+*.egg-info
+__pycache__

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cd JupyterNotebookImageExporter; python setup.py install
 ## Usage
 
 ### From command line
-```junix <notebook_filepath> -o output_dir```
+```junix /path/to/notebook -o path/to/output/directory```
 
 *filepath*: Notebook filepath<br/>
 *-o* is an optional argument. If -o is not specified, output directory is current directory (pwd).<br/>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Junix (JUpyter Notebook Image eXporter)
 
-Finding troublesome to export images from your notebook?<br/>
-Junix is a simple python package to export plots embed in a Jupyter Notebook.
+Finding it troublesome to export images from notebook?<br/>
+Junix is a simple python package to export plots within Jupyter Notebook.
 
 ## Installation
 
@@ -42,11 +42,6 @@ By running the following commands:
 2 image files will be generated in the same folder as the notebook file (see screenshot below): <br/>
 
 <img width="333" alt="Screenshot 2019-09-15 at 1 52 45 PM" src="https://user-images.githubusercontent.com/9989010/64917371-5fa84000-d7c2-11e9-9f65-e9a53fc7d781.png"> 
-
-## Resources
-
-## Authors
-Damien Marlier
 
 ## License
 This project is licensed under the MIT License

--- a/README.md
+++ b/README.md
@@ -31,9 +31,17 @@ python setup.py install
 
 ### Example
 
-Let's consider 
+Let's consider the following notebook ```example.ipynb```:
 
-Running 
+<img width="865" alt="Screenshot 2019-09-15 at 2 06 49 PM" src="https://user-images.githubusercontent.com/9989010/64917363-2cfe4780-d7c2-11e9-8174-ed2924d17e31.png">
+
+By running the following commands:
+- ```junix example.ipynb``` (with command line) <br/>
+- ```import junix; junix.export_images(filepath="example.ipynb")``` (within python terminal) <br/>
+
+2 image files will be generated in the same folder as the notebook file (see screenshot below): <br/>
+
+<img width="333" alt="Screenshot 2019-09-15 at 1 52 45 PM" src="https://user-images.githubusercontent.com/9989010/64917371-5fa84000-d7c2-11e9-9f65-e9a53fc7d781.png"> 
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ Junix is a simple python package to export plots within Jupyter Notebook.
 ### Using source code
 ```
 git clone https://github.com/damienmarlier51/JupyterNotebookImageExporter.git
-cd JupyterNotebookImageExporter
-python setup.py install
+cd JupyterNotebookImageExporter; python setup.py install
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cd JupyterNotebookImageExporter; python setup.py install
 ## Usage
 
 ### From command line
-```junix filepath -o output_dir```
+```junix <notebook_filepath> -o output_dir```
 
 *filepath*: Notebook filepath<br/>
 *-o* is an optional argument. If -o is not specified, output directory is current directory (pwd).<br/>

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Finding it troublesome to export images from notebook?<br/>
 Junix is a simple python package to export plots within Jupyter Notebook.
 
+Output formats include a directory of images or a PDF file (via [img2pdf](https://pypi.org/project/img2pdf/)).
+
 ## Installation
 
 ### Using pip
@@ -27,6 +29,13 @@ cd JupyterNotebookImageExporter; python setup.py install
 
 *filepath*: Notebook filepath<br/>
 *output_dir*: Directory where to output notebook images<br/>
+
+### Exporting PDFs
+```junix /path/to/notebook -p path/to/output.pdf```
+
+or from Python,
+
+```import junix; junix.export_pdf(filepath, output_pdf)```
 
 ### Example
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# Junix (JUpyter Notebook Image eXporter)
+
+Finding troublesome to export images from your notebook?<br/>
+Junix is a simple python package to export plots embed in a Jupyter Notebook.
+
+## Installation
+
+### Using pip
+```pip install junix```
+
+### Using source code
+```
+git clone https://github.com/damienmarlier51/JupyterNotebookImageExporter.git
+cd JupyterNotebookImageExporter
+python setup.py install
+```
+
+## Usage
+
+### From command line
+```junix filepath -o output_dir```
+
+*filepath*: Notebook filepath<br/>
+*-o* is an optional argument. If -o is not specified, output directory is current directory (pwd).<br/>
+  
+### From Python
+```import junix; junix.export_images(filepath, output_directory)```
+
+*filepath*: Notebook filepath<br/>
+*output_directory*: Directory where to output notebook images<br/>
+
+### Example
+
+Let's consider 
+
+Running 
+
+## Resources
+
+## Authors
+Damien Marlier
+
+## License
+This project is licensed under the MIT License

--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ python setup.py install
 *-o* is an optional argument. If -o is not specified, output directory is current directory (pwd).<br/>
   
 ### From Python
-```import junix; junix.export_images(filepath, output_directory)```
+```import junix; junix.export_images(filepath, output_dir)```
 
 *filepath*: Notebook filepath<br/>
-*output_directory*: Directory where to output notebook images<br/>
+*output_dir*: Directory where to output notebook images<br/>
 
 ### Example
 

--- a/junix/cli.py
+++ b/junix/cli.py
@@ -1,4 +1,4 @@
-from junix.exporter import export_images
+from junix.exporter import export_images, export_pdf
 import argparse
 
 
@@ -7,9 +7,14 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('filepath', type=str, help='Notebook filepath')
     parser.add_argument('-o', '--output_dir', type=str, default=None, help='Directory where to export the images')
+    parser.add_argument('-p', '--output_pdf', type=str, default=None, help='Filename to export a PDF; takes precedence over -o')
 
     args = parser.parse_args()
     notebook_filepath = args.filepath
     output_directory = args.output_dir
+    output_pdf = args.output_pdf
 
-    export_images(notebook_filepath, output_directory)
+    if output_pdf is not None:
+        export_pdf(notebook_filepath, output_pdf)
+    else:
+        export_images(notebook_filepath, output_directory)

--- a/junix/exporter.py
+++ b/junix/exporter.py
@@ -3,11 +3,11 @@ import json
 import os
 
 
-def export_images(notebook_filepath,
-                  output_directory=None):
+def export_images(filepath,
+                  output_dir=None):
 
-    notebook_image_exporter = NotebookImageExporter(notebook_filepath,
-                                                    output_directory)
+    notebook_image_exporter = NotebookImageExporter(filepath,
+                                                    output_dir)
 
     notebook_image_exporter.save_images()
 

--- a/junix/exporter.py
+++ b/junix/exporter.py
@@ -4,7 +4,7 @@ import os
 
 
 def export_images(notebook_filepath,
-                  output_directory):
+                  output_directory=None):
 
     notebook_image_exporter = NotebookImageExporter(notebook_filepath,
                                                     output_directory)

--- a/junix/exporter.py
+++ b/junix/exporter.py
@@ -83,10 +83,7 @@ class NotebookImageExporter():
     def save_images(self):
 
         if self.output_directory is None:
-            output_directory = self.notebook_directory \
-                               + os.sep \
-                               + self.notebook_filename.replace(".ipynb", "") \
-                               + "_images"
+            output_directory = "."
         else:
             output_directory = self.output_directory
 

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,12 @@ from setuptools import setup
 
 setup(
     name="junix",
-    version="0.1.1",
+    version="0.2.0",
     author="Damien Marlier",
     author_email="damien.marlier@hotmail.fr",
     description="Simple library to export images from Jupyter notebook",
     packages=["junix"],
+    install_requires=['img2pdf>=0.4'],
     entry_points={
         "console_scripts": ['junix = junix.cli:main']
     }

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="junix",
-    version="0.1.0",
+    version="0.1.1",
     author="Damien Marlier",
     author_email="damien.marlier@hotmail.fr",
     description="Simple library to export images from Jupyter notebook",


### PR DESCRIPTION
I've added the feature of exporting images to a PDF file. I found this useful for quickly creating a slide deck from a bunch of plots in a notebook.

Usage is via the new command line option `-p` or the `export_pdf()` method.

It does add one dependency, the `img2pdf` library.

Sending it here as a pull request in case you are interested in merging it into the official pip package.